### PR TITLE
ci: disable cache and upgrade Node.js to v24

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,11 +18,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm ci
 
   lint:
@@ -35,11 +35,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm run lint
 
   build:
@@ -52,11 +52,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm run build
       - uses: actions/upload-artifact@v4
         with:
@@ -73,11 +73,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm run test
 
   e2e:
@@ -95,11 +95,11 @@ jobs:
           mv -v pdf_out/* ./pdf/out
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm run test:e2e
 
   generate_pdf:

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm ci
 
   refresh:
@@ -38,11 +38,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm run refresh-components-data
         env:
           GITHUB_PAT: ${{ secrets.X_GITHUB_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm ci
 
   deploy:
@@ -41,11 +41,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          node-version: '24'
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: node_modules
+      #     key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm run build
       - uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
- Comment out actions/cache steps to avoid cache-related CI failures
- Upgrade node-version from '22' to '24' in all workflows